### PR TITLE
Moved mockery/mockery to the dev dependencies list in composer.json config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
         "php": "^8.0",
         "google/cloud-storage": "^1.24",
         "league/flysystem": "^1.1",
-        "mockery/mockery": "^1.4",
         "ext-fileinfo": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
+        "mockery/mockery": "^1.4",
         "phpunit/phpunit": "^9.5",
         "spatie/ray": "^1.28",
         "vimeo/psalm": "^4.8"


### PR DESCRIPTION
The problem is described in this issue - https://github.com/spatie/flysystem-google-cloud-storage/issues/3